### PR TITLE
docs: add newcomer onboarding overview

### DIFF
--- a/docs/en/newcomer_overview.md
+++ b/docs/en/newcomer_overview.md
@@ -1,0 +1,30 @@
+# Newcomer Overview
+
+## Quick summary
+Agent Tool Description Format (ATDF) is an implementation-agnostic specification that standardizes how AI agents discover and operate external tools. It defines JSON schemas for tool catalogs and enriched error payloads so agents can reason about when and how to call available capabilities.
+
+## Repository structure at a glance
+- **Schemas (`schema/`)** – Authoritative JSON Schema documents for the classic (1.x) and enhanced (2.x) ATDF descriptors as well as the enriched error envelope.
+- **Python tooling (`tools/`, `sdk/`)** – Command line validators, conversion helpers, and a Python SDK (`ATDFTool`, toolbox loaders, multilingual search, auto-selection) that parse descriptors and execute catalog queries programmatically.
+- **JavaScript SDK (`js/`)** – Node.js/browser utilities mirroring the Python SDK features, including optional vector search, localization helpers, and MCP→ATDF conversion helpers.
+- **Examples (`examples/`)** – FastAPI reference application, scenario demos, and integration tests that demonstrate end-to-end ATDF error handling, booking flows, and Model Context Protocol (MCP) wiring.
+- **Documentation (`docs/`)** – Specification, implementation guides, integration walkthroughs (FastAPI, n8n, monitoring), and multilingual content kept in sync across English/Spanish/Portuguese.
+- **Automation & workflows (`n8n-*`, `monitoring/`, `scripts/`)** – Ready-to-import n8n workflows, monitoring dashboards, and helper scripts for spinning up demo environments.
+
+## Concepts to learn first
+1. **Tool descriptors** – Understand required vs. optional fields in classic vs. enhanced ATDF schemas, including localization metadata, prerequisites, and worked examples.
+2. **Enriched error responses** – Study the shared error envelope (`schema/enriched_response_schema.json`) so your services surface actionable remediation hints for agents.
+3. **SDK usage patterns** – Review how the Python/JS SDKs load catalogs, perform text/vector search, and auto-select tools so you avoid re-implementing parsing logic.
+4. **FastAPI MCP bridge** – Treat the sample app in `examples/` as both a reference implementation and an integration testbed when wiring ATDF into new runtimes.
+
+## Working effectively in the repo
+- Validate descriptors early with `tools/validator.py` or `tools/validate_enhanced.py` before distributing them.
+- Run both Python and JavaScript test suites (`python tests/run_all_tests.py`, `npm test` inside `js/`) to catch regressions across SDKs.
+- Use the FastAPI + n8n workflows as system tests when adjusting server logic or MCP integrations.
+- Keep documentation localized: whenever you change guides in `docs/en`, mirror the updates in `docs/es` and `docs/pt`.
+
+## Next steps for onboarding
+1. Read the **Implementation Guide** (`docs/IMPLEMENTATION_GUIDE.md`) for architectural patterns, validation strategy, and deployment considerations.
+2. Explore the **SDK examples** under `sdk/` and `js/` to see catalog loading, multilingual metadata handling, and schema extraction in practice.
+3. Follow the **n8n + MCP walkthroughs** (`docs/*n8n*`) to understand end-to-end orchestration and error handling in automation workflows.
+4. Review the **monitoring playbooks** (`monitoring/`) to learn how production deployments track ATDF error metrics and operational health.

--- a/docs/es/newcomer_overview.md
+++ b/docs/es/newcomer_overview.md
@@ -1,0 +1,30 @@
+# Guía para Nuevas Personas en el Proyecto
+
+## Resumen rápido
+Agent Tool Description Format (ATDF) es una especificación independiente de la implementación que estandariza cómo los agentes de IA descubren y operan herramientas externas. Define esquemas JSON para catálogos de herramientas y respuestas de error enriquecidas, permitiendo que los agentes razonen sobre cuándo y cómo invocar cada capacidad disponible.
+
+## Estructura del repositorio
+- **Esquemas (`schema/`)** – Documentos JSON Schema autorizados para los descriptores ATDF clásicos (1.x) y mejorados (2.x), junto con el sobre de errores enriquecidos.
+- **Herramientas en Python (`tools/`, `sdk/`)** – Validadores de línea de comandos, utilidades de conversión y un SDK en Python (`ATDFTool`, cargadores de catálogos, búsqueda multilingüe, auto-selección) que interpretan descriptores y ejecutan consultas de catálogo de forma programática.
+- **SDK de JavaScript (`js/`)** – Utilidades para Node.js/navegador que replican las funciones del SDK de Python, incluyendo búsqueda vectorial opcional, asistentes de localización y conversores MCP→ATDF.
+- **Ejemplos (`examples/`)** – Aplicación de referencia en FastAPI, demostraciones de escenarios y pruebas de integración que muestran un manejo de errores ATDF de extremo a extremo, flujos de reservas y conexión con Model Context Protocol (MCP).
+- **Documentación (`docs/`)** – Especificaciones, guías de implementación, recorridos de integración (FastAPI, n8n, monitoreo) y contenido multilingüe sincronizado entre inglés/español/portugués.
+- **Automatización y flujos (`n8n-*`, `monitoring/`, `scripts/`)** – Flujos n8n listos para importar, tableros de monitoreo y scripts de apoyo para levantar entornos de demostración.
+
+## Conceptos clave a dominar primero
+1. **Descriptores de herramientas** – Comprende los campos obligatorios y opcionales en los esquemas ATDF clásico y mejorado, incluyendo metadatos de localización, prerrequisitos y ejemplos guiados.
+2. **Respuestas de error enriquecidas** – Revisa el sobre de error compartido (`schema/enriched_response_schema.json`) para que tus servicios entreguen sugerencias de remediación accionables a los agentes.
+3. **Patrones de uso de los SDK** – Estudia cómo los SDK de Python y JavaScript cargan catálogos, realizan búsqueda textual/vectorial y auto-seleccionan herramientas para evitar reimplementar lógica de parseo.
+4. **Puente FastAPI MCP** – Usa la aplicación de ejemplo en `examples/` como implementación de referencia y banco de pruebas al integrar ATDF en nuevos entornos de ejecución.
+
+## Buenas prácticas al trabajar en el repositorio
+- Valida los descriptores desde temprano con `tools/validator.py` o `tools/validate_enhanced.py` antes de distribuirlos.
+- Ejecuta las suites de pruebas en Python y JavaScript (`python tests/run_all_tests.py`, `npm test` dentro de `js/`) para detectar regresiones en los SDK.
+- Utiliza los flujos FastAPI + n8n como pruebas de sistema al ajustar la lógica del servidor o las integraciones MCP.
+- Mantén la documentación localizada: cualquier cambio en `docs/en` debe replicarse en `docs/es` y `docs/pt`.
+
+## Pasos siguientes para tu onboarding
+1. Lee la **Guía de Implementación** (`docs/IMPLEMENTATION_GUIDE.md`) para conocer los patrones arquitectónicos, la estrategia de validación y las consideraciones de despliegue.
+2. Explora los **ejemplos de los SDK** en `sdk/` y `js/` para observar la carga de catálogos, el manejo de metadatos multilingües y la extracción de esquemas en acción.
+3. Sigue los **recorridos n8n + MCP** (`docs/*n8n*`) para comprender la orquestación extremo a extremo y el manejo de errores en flujos de automatización.
+4. Revisa los **manuales de monitoreo** (`monitoring/`) para aprender cómo los despliegues en producción rastrean métricas de errores ATDF y salud operativa.

--- a/docs/pt/newcomer_overview.md
+++ b/docs/pt/newcomer_overview.md
@@ -1,0 +1,30 @@
+# Guia para Pessoas Recém-Chegadas ao Projeto
+
+## Resumo rápido
+Agent Tool Description Format (ATDF) é uma especificação independente de implementação que padroniza como agentes de IA descobrem e operam ferramentas externas. Ela define esquemas JSON para catálogos de ferramentas e respostas de erro enriquecidas, permitindo que os agentes decidam quando e como acionar cada capacidade disponível.
+
+## Estrutura do repositório
+- **Esquemas (`schema/`)** – Documentos JSON Schema oficiais para os descritores ATDF clássicos (1.x) e aprimorados (2.x), além do envelope de erros enriquecidos.
+- **Ferramentas em Python (`tools/`, `sdk/`)** – Validadores de linha de comando, utilitários de conversão e um SDK em Python (`ATDFTool`, carregadores de catálogos, busca multilíngue, auto-seleção) que interpretam descritores e executam consultas de catálogo programaticamente.
+- **SDK JavaScript (`js/`)** – Utilitários para Node.js/navegador que espelham os recursos do SDK em Python, incluindo busca vetorial opcional, assistentes de localização e conversores MCP→ATDF.
+- **Exemplos (`examples/`)** – Aplicação de referência em FastAPI, demonstrações de cenários e testes de integração que exibem o tratamento de erros ATDF ponta a ponta, fluxos de reserva e integração com o Model Context Protocol (MCP).
+- **Documentação (`docs/`)** – Especificações, guias de implementação, tutoriais de integração (FastAPI, n8n, monitoramento) e conteúdo multilíngue sincronizado entre inglês/espanhol/português.
+- **Automação e fluxos (`n8n-*`, `monitoring/`, `scripts/`)** – Workflows prontos para importar no n8n, painéis de monitoramento e scripts auxiliares para levantar ambientes de demonstração.
+
+## Conceitos fundamentais para aprender primeiro
+1. **Descritores de ferramentas** – Entenda os campos obrigatórios e opcionais nos esquemas ATDF clássico e aprimorado, incluindo metadados de localização, pré-requisitos e exemplos guiados.
+2. **Respostas de erro enriquecidas** – Estude o envelope de erro compartilhado (`schema/enriched_response_schema.json`) para que seus serviços entreguem sugestões de correção acionáveis aos agentes.
+3. **Padrões de uso dos SDKs** – Observe como os SDKs de Python e JavaScript carregam catálogos, realizam busca textual/vetorial e auto-selecionam ferramentas para evitar reimplementar lógica de parsing.
+4. **Ponte FastAPI MCP** – Utilize o aplicativo de exemplo em `examples/` como implementação de referência e ambiente de testes ao integrar ATDF em novos runtimes.
+
+## Boas práticas ao colaborar no repositório
+- Valide descritores desde cedo com `tools/validator.py` ou `tools/validate_enhanced.py` antes de distribuí-los.
+- Execute as suítes de testes em Python e JavaScript (`python tests/run_all_tests.py`, `npm test` dentro de `js/`) para detectar regressões nos SDKs.
+- Use os workflows FastAPI + n8n como testes de sistema ao ajustar a lógica do servidor ou integrações MCP.
+- Mantenha a documentação localizada: quaisquer mudanças em `docs/en` devem ser refletidas em `docs/es` e `docs/pt`.
+
+## Próximos passos para o onboarding
+1. Leia o **Guia de Implementação** (`docs/IMPLEMENTATION_GUIDE.md`) para entender padrões arquiteturais, estratégia de validação e considerações de implantação.
+2. Explore os **exemplos dos SDKs** em `sdk/` e `js/` para ver carga de catálogos, manipulação de metadados multilíngues e extração de esquemas na prática.
+3. Siga os **tutoriais n8n + MCP** (`docs/*n8n*`) para compreender a orquestração ponta a ponta e o tratamento de erros em fluxos de automação.
+4. Revise os **roteiros de monitoramento** (`monitoring/`) para aprender como implantações em produção acompanham métricas de erro ATDF e saúde operacional.


### PR DESCRIPTION
## Summary
- add newcomer onboarding overview guides in English, Spanish, and Portuguese
- outline repository layout, core concepts, workflows, and suggested next steps for onboarding

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68dfcd2e1360832d90695ed867f58b89