### PR TITLE
fix: improve exception handling in tooling scripts

### DIFF
--- a/examples/vector_search_example.py
+++ b/examples/vector_search_example.py
@@ -136,8 +136,11 @@ async def search_examples(vector_store: ATDFVectorStore) -> None:
                         print(f"      Categoría: {metadata['category']}")
                     if "tags" in metadata and metadata["tags"]:
                         print(f"      Etiquetas: {', '.join(metadata['tags'])}")
-                except:
-                    pass
+                except (json.JSONDecodeError, TypeError) as exc:
+                    print(
+                        "      No se pudieron interpretar los metadatos del resultado: "
+                        f"{exc}"
+                    )
 
 
 async def main():

--- a/scripts/setup_monitoring.py
+++ b/scripts/setup_monitoring.py
@@ -149,8 +149,11 @@ class MonitoringSetup:
                 response = requests.get("http://localhost:3000/api/health", timeout=5)
                 if response.status_code == 200:
                     break
-            except requests.RequestException:
-                pass
+            except requests.RequestException as exc:
+                print(
+                    "Grafana health check attempt "
+                    f"{i + 1}/{max_retries} failed: {exc}"
+                )
             
             if i < max_retries - 1:
                 print(f"Waiting for Grafana... ({i+1}/{max_retries})")
@@ -188,8 +191,11 @@ class MonitoringSetup:
                     if response.status_code == 200:
                         print("✅ ATDF application is ready")
                         return True
-                except requests.RequestException:
-                    pass
+                except requests.RequestException as exc:
+                    print(
+                        "Application health check attempt "
+                        f"{i + 1}/{max_retries} failed: {exc}"
+                    )
                 
                 if i < max_retries - 1:
                     print(f"Waiting for application... ({i+1}/{max_retries})")

--- a/tests/test_vector_search.py
+++ b/tests/test_vector_search.py
@@ -18,6 +18,7 @@ import shutil
 from unittest import mock
 
 import sys
+import warnings
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
 from sdk.atdf_sdk import ATDFTool, ATDFToolbox
@@ -29,8 +30,13 @@ try:
     import lancedb
     import sentence_transformers
     VECTOR_DEPENDENCIES_AVAILABLE = True
-except ImportError:
-    pass
+except ImportError as exc:
+    warnings.warn(
+        "Vector search dependencies are not available; related tests will be skipped. "
+        f"Missing dependency detail: {exc}",
+        RuntimeWarning,
+    )
+    VECTOR_DEPENDENCIES_AVAILABLE = False
 
 # Herramientas de ejemplo para las pruebas
 SAMPLE_TOOLS = [


### PR DESCRIPTION
## Summary
- add warnings for missing vector search dependencies during test imports
- log connection failures while waiting for Grafana and the ATDF app to become healthy
- report metadata parsing issues in the vector search example instead of silently ignoring them

## Testing
- python -m compileall tests/test_vector_search.py scripts/setup_monitoring.py examples/vector_search_example.py

------
https://chatgpt.com/codex/tasks/task_e_68e022668fe4832d9c7368b09849831e