### PR TITLE
fix: align search cli table configuration

### DIFF
--- a/sdk/vector_search/search_cli.py
+++ b/sdk/vector_search/search_cli.py
@@ -31,7 +31,7 @@ class ATDFSearchCLI:
         self.vector_store = None
         self.db_path = "./atdf_vector_db"
         self.model_name = "all-MiniLM-L6-v2"
-        self.collection_name = "atdf_tools"
+        self.table_name = "atdf_tools"
 
     async def initialize(self, db_path: Optional[str] = None) -> bool:
         """
@@ -49,7 +49,7 @@ class ATDFSearchCLI:
         self.vector_store = ATDFVectorStore(
             db_path=self.db_path,
             model_name=self.model_name,
-            collection_name=self.collection_name,
+            table_name=self.table_name,
         )
 
         return await self.vector_store.initialize()

--- a/tests/test_vector_search_search_cli.py
+++ b/tests/test_vector_search_search_cli.py
@@ -1,0 +1,41 @@
+"""Pruebas para la CLI de búsqueda vectorial de ATDF."""
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest import mock, TestCase
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+from sdk.vector_search.search_cli import ATDFSearchCLI  # noqa: E402
+
+
+class TestATDFSearchCLI(TestCase):
+    """Pruebas mínimas para detectar cambios de firma en la CLI."""
+
+    def test_initialize_uses_table_name_argument(self) -> None:
+        """La inicialización debe usar el argumento soportado ``table_name``."""
+
+        cli = ATDFSearchCLI()
+        self.assertEqual(cli.table_name, "atdf_tools")
+
+        vector_store_instance = mock.MagicMock()
+        vector_store_instance.initialize = mock.AsyncMock(return_value=True)
+
+        with mock.patch(
+            "sdk.vector_search.search_cli.ATDFVectorStore",
+            return_value=vector_store_instance,
+        ) as mock_store_cls:
+            result = asyncio.run(cli.initialize())
+
+        self.assertTrue(result)
+        mock_store_cls.assert_called_once_with(
+            db_path=cli.db_path,
+            model_name=cli.model_name,
+            table_name=cli.table_name,
+        )
+        vector_store_instance.initialize.assert_awaited()


### PR DESCRIPTION
## Summary
- update the vector search CLI to configure LanceDB with the supported `table_name` argument
- add a smoke test that exercises `ATDFSearchCLI.initialize()` to guard against signature regressions

## Testing
- python -m unittest tests.test_vector_search_search_cli

------
https://chatgpt.com/codex/tasks/task_e_68e032f37e64832d8f17b906a7efa97b