### PR TITLE
Fix vector search example data directory

### DIFF
--- a/docs/advanced-usage/vector-search.md
+++ b/docs/advanced-usage/vector-search.md
@@ -55,6 +55,8 @@ Opcional: crea una cuenta gratuita en [Hugging Face](https://huggingface.co/) pa
 
 ## 🔍 Implementación básica
 
+> ℹ️ El repositorio incluye un catálogo de herramientas de ejemplo en `examples/output`. El script `examples/vector_search_example.py` usa esa ruta por defecto; puedes añadir tus propios archivos JSON o YAML en ese directorio o actualizar la constante `TOOLS_DIR` del script para apuntar a otra ubicación.
+
 ```js
 const lancedb = require("lancedb");
 const { HfInference } = require("@huggingface/inference");

--- a/examples/vector_search_example.py
+++ b/examples/vector_search_example.py
@@ -20,8 +20,9 @@ from sdk.atdf_sdk import load_tools_from_directory
 from sdk.vector_search import ATDFVectorStore
 
 # Ruta de ejemplo para herramientas y base de datos
-TOOLS_DIR = os.path.join(os.path.dirname(__file__), "..", "examples", "tools")
-DB_PATH = os.path.join(os.path.dirname(__file__), "..", "examples", "vector_db")
+BASE_EXAMPLES_DIR = Path(__file__).resolve().parent
+TOOLS_DIR = BASE_EXAMPLES_DIR / "output"
+DB_PATH = BASE_EXAMPLES_DIR / "output" / "vector_db"
 
 
 async def create_index() -> ATDFVectorStore:
@@ -31,18 +32,31 @@ async def create_index() -> ATDFVectorStore:
     Returns:
         Instancia de ATDFVectorStore inicializada
     """
-    print(f"Cargando herramientas desde {TOOLS_DIR}...")
-    tools = load_tools_from_directory(Path(TOOLS_DIR))
+    if not TOOLS_DIR.exists():
+        print(f"No se encontró el directorio de herramientas de ejemplo: {TOOLS_DIR}")
+        print(
+            "Crea la carpeta o actualiza TOOLS_DIR para apuntar a tus archivos JSON/YAML de herramientas."
+        )
+        sys.exit(1)
+
+    print(
+        f"Cargando herramientas de ejemplo desde {TOOLS_DIR}...\n"
+        "Coloca tus propios archivos JSON o YAML en este directorio o ajusta TOOLS_DIR para usar otra ruta."
+    )
+    tools = load_tools_from_directory(TOOLS_DIR)
 
     if not tools:
         print(f"No se encontraron herramientas en {TOOLS_DIR}")
-        print("Asegúrate de tener archivos JSON de herramientas en el directorio")
+        print(
+            "Asegúrate de que el directorio contenga archivos JSON o YAML válidos;"
+            " puedes copiar los ejemplos provistos o reemplazarlos por tus propias herramientas."
+        )
         sys.exit(1)
 
     print(f"Se cargaron {len(tools)} herramientas")
 
     # Crear almacén vectorial
-    vector_store = ATDFVectorStore(db_path=DB_PATH)
+    vector_store = ATDFVectorStore(db_path=str(DB_PATH))
 
     # Inicializar y crear índice
     await vector_store.initialize()
@@ -138,7 +152,7 @@ async def search_examples(vector_store: ATDFVectorStore) -> None:
 async def main():
     """Función principal del script de ejemplo."""
     # Crear directorio para la base de datos si no existe
-    os.makedirs(DB_PATH, exist_ok=True)
+    DB_PATH.mkdir(parents=True, exist_ok=True)
 
     # Crear índice
     vector_store = await create_index()


### PR DESCRIPTION
## Summary
- point the vector search example to the bundled sample tool catalog under `examples/output` and improve messaging about supplying custom tool files
- update the vector search guide to reference the new sample location so documentation matches the example

## Testing
- python -m compileall examples/vector_search_example.py

------
https://chatgpt.com/codex/tasks/task_e_68e032f2bd9c832da1332a39c6f1e8c6