### PR TITLE
fix: tolerate BOM in ARDF sample loader

### DIFF
--- a/server_ardf_mcp.py
+++ b/server_ardf_mcp.py
@@ -14,6 +14,7 @@ from jsonschema import validators
 
 APP_ROOT = Path(__file__).parent
 SAMPLES_DIR = APP_ROOT / "examples" / "ardf_samples"
+UTF8_BOM_TOLERANT = "utf-8-sig"
 MANIFEST_PATH = APP_ROOT / "mcp_manifest.json"
 SCHEMA_PATH = APP_ROOT / "schema" / "ardf.schema.json"
 
@@ -60,7 +61,7 @@ class ResourceIndex:
     def _load_all(self) -> List[Dict[str, object]]:
         resources: List[Dict[str, object]] = []
         for path in sorted(self.directory.glob("*.json")):
-            with path.open("r", encoding="utf-8") as handle:
+            with path.open("r", encoding=UTF8_BOM_TOLERANT) as handle:
                 resources.append(json.load(handle))
         return resources
 
@@ -76,7 +77,7 @@ class ResourceIndex:
         validator = get_validator()
         for path in sorted(self.directory.glob("*.json")):
             try:
-                with path.open("r", encoding="utf-8") as handle:
+                with path.open("r", encoding=UTF8_BOM_TOLERANT) as handle:
                     data = json.load(handle)
             except Exception as e:
                 errors.append({


### PR DESCRIPTION
## Summary
- load ARDF sample JSON using a BOM-tolerant UTF-8 codec so legacy descriptors with byte order marks do not crash the MCP server

## Testing
- python - <<'PY'
import asyncio
import json
from httpx import ASGITransport, AsyncClient
from server_ardf_mcp import app

async def main():
    transport = ASGITransport(app=app)
    async with AsyncClient(transport=transport, base_url="http://test") as client:
        for path in ["/datasets", "/connectors", "/resources"]:
            response = await client.request("GET", path)
            print(path, response.status_code)
            print(json.dumps(response.json(), indent=2))

asyncio.run(main())
PY

------
https://chatgpt.com/codex/tasks/task_e_68e5661aa64c832d86213198b2e10442