### PR TITLE
feat: publish dataset and connector samples

### DIFF
--- a/examples/ardf_samples/connector_crm.json
+++ b/examples/ardf_samples/connector_crm.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "1.0.0",
+  "resource_id": "connector_crm_v1",
+  "resource_type": "connector",
+  "description": "REST connector that exposes CRM contacts with read/write access.",
+  "when_to_use": "Use to look up, create, or update customer records from the CRM platform.",
+  "content": {
+    "type": "connector/spec",
+    "data": {
+      "interface": "http",
+      "base_url": "https://crm.internal.example.com/api",
+      "auth": {
+        "type": "bearer",
+        "env": "CRM_API_TOKEN"
+      },
+      "endpoints": [
+        {
+          "name": "list_contacts",
+          "method": "GET",
+          "path": "/contacts",
+          "query": {
+            "email": {
+              "type": "string",
+              "description": "Filter contacts by email address."
+            }
+          },
+          "response": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "email": { "type": "string", "format": "email" },
+                "first_name": { "type": "string" },
+                "last_name": { "type": "string" },
+                "lifecycle_stage": { "type": "string" }
+              }
+            }
+          }
+        },
+        {
+          "name": "update_contact",
+          "method": "PATCH",
+          "path": "/contacts/{id}",
+          "body": {
+            "type": "object",
+            "properties": {
+              "first_name": { "type": "string" },
+              "last_name": { "type": "string" },
+              "phone": { "type": "string" }
+            }
+          },
+          "response": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "updated_at": { "type": "string", "format": "date-time" }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "domain": "crm",
+    "version": "1.0.0",
+    "owner": "Sales Operations",
+    "tags": ["contacts", "customer", "connector"],
+    "quality": "beta"
+  },
+  "examples": [
+    {
+      "name": "Lookup contact by email",
+      "input": "Find the CRM record for maria.garcia@example.com",
+      "output": "Returns a contact payload with the matching email address."
+    }
+  ]
+}

--- a/examples/ardf_samples/dataset_products.json
+++ b/examples/ardf_samples/dataset_products.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.0.0",
+  "resource_id": "dataset_products_v1",
+  "resource_type": "dataset",
+  "description": "Structured catalog of products enriched with pricing and inventory signals.",
+  "when_to_use": "Consult when users ask for product availability, pricing comparisons, or SKU metadata.",
+  "content": {
+    "type": "dataset/spec",
+    "data": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "sku": { "type": "string", "description": "Internal stock keeping unit." },
+          "name": { "type": "string", "description": "Localized product name." },
+          "category": { "type": "string", "description": "Merchandising category path." },
+          "price": { "type": "number", "description": "Current list price in minor currency units." },
+          "currency": { "type": "string", "description": "ISO-4217 currency code." },
+          "inventory_level": { "type": "integer", "description": "Available units ready to ship." },
+          "updated_at": { "type": "string", "format": "date-time", "description": "Last synchronization timestamp." }
+        },
+        "required": ["sku", "name", "price", "currency", "inventory_level"]
+      },
+      "query": "SELECT sku, name, category, price, currency, inventory_level, updated_at FROM analytics.products WHERE sku = :sku",
+      "connector": "connector_crm_v1"
+    }
+  },
+  "metadata": {
+    "domain": "retail",
+    "version": "1.0.0",
+    "owner": "Data Platform",
+    "tags": ["catalog", "pricing", "inventory"],
+    "quality": "gold"
+  },
+  "examples": [
+    {
+      "name": "Check stock for a SKU",
+      "input": "How many units of SKU-90210 do we have available?",
+      "output": "Returns the inventory_level and pricing information for SKU-90210."
+    }
+  ]
+}

--- a/mcp_manifest.json
+++ b/mcp_manifest.json
@@ -3,12 +3,54 @@
   "version": "1.0.0",
   "description": "MCP-compatible server exposing ARDF resources for agents.",
   "resources": [
-    { "type": "tool", "path": "/tools" },
-    { "type": "prompt", "path": "/prompts" },
-    { "type": "document", "path": "/documents" },
-    { "type": "workflow", "path": "/workflows" },
-    { "type": "policy", "path": "/policies" },
-    { "type": "model", "path": "/models" }
+    {
+      "type": "tool",
+      "path": "/tools",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "prompt",
+      "path": "/prompts",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "document",
+      "path": "/documents",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "workflow",
+      "path": "/workflows",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "policy",
+      "path": "/policies",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "model",
+      "path": "/models",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "dataset",
+      "path": "/datasets",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "connector",
+      "path": "/connectors",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    }
   ],
   "meta": {
     "ardf_schema": "/schema/ardf.schema.json",

--- a/schema/ardf.schema.json
+++ b/schema/ardf.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://example.org/ardf.schema.json",
+  "$id": "https://ardf.io/schema/v1",
   "title": "Agent Resource Description Format (ARDF) v1.0.0",
   "type": "object",
   "required": [

--- a/server_ardf_mcp.py
+++ b/server_ardf_mcp.py
@@ -14,6 +14,7 @@ from jsonschema import validators
 
 APP_ROOT = Path(__file__).parent
 SAMPLES_DIR = APP_ROOT / "examples" / "ardf_samples"
+UTF8_BOM_TOLERANT = "utf-8-sig"
 MANIFEST_PATH = APP_ROOT / "mcp_manifest.json"
 SCHEMA_PATH = APP_ROOT / "schema" / "ardf.schema.json"
 
@@ -60,7 +61,7 @@ class ResourceIndex:
     def _load_all(self) -> List[Dict[str, object]]:
         resources: List[Dict[str, object]] = []
         for path in sorted(self.directory.glob("*.json")):
-            with path.open("r", encoding="utf-8") as handle:
+            with path.open("r", encoding=UTF8_BOM_TOLERANT) as handle:
                 resources.append(json.load(handle))
         return resources
 
@@ -76,7 +77,7 @@ class ResourceIndex:
         validator = get_validator()
         for path in sorted(self.directory.glob("*.json")):
             try:
-                with path.open("r", encoding="utf-8") as handle:
+                with path.open("r", encoding=UTF8_BOM_TOLERANT) as handle:
                     data = json.load(handle)
             except Exception as e:
                 errors.append({


### PR DESCRIPTION
## Summary
- load ARDF sample JSON using a BOM-tolerant UTF-8 codec so legacy descriptors with byte order marks do not crash the MCP server
- add dataset and connector ARDF samples and advertise the canonical media type/profile in the manifest

## Testing
- python examples/ardf_samples/validate_python.py examples/ardf_samples/dataset_products.json
- python examples/ardf_samples/validate_python.py examples/ardf_samples/connector_crm.json
- python - <<'PY'
import asyncio
import json
from httpx import ASGITransport, AsyncClient
from server_ardf_mcp import app

async def fetch(client, path):
    response = await client.request("GET", path)
    return response

async def main():
    transport = ASGITransport(app=app)
    async with AsyncClient(transport=transport, base_url="http://test") as client:
        manifest = await fetch(client, "/manifest")
        print("/manifest", manifest.status_code)
        print(json.dumps(manifest.json(), indent=2))
        for path in ["/datasets", "/connectors", "/resources"]:
            response = await fetch(client, path)
            print(path, response.status_code)
            print(json.dumps(response.json(), indent=2))

asyncio.run(main())
PY

------
https://chatgpt.com/codex/tasks/task_e_68e5661aa64c832d86213198b2e10442