### PR TITLE
fix: enforce dataset and connector schema rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,9 @@ ATDF solved the problem of expressing callable tools. Modern agent ecosystems al
 - `how_to_use` becomes a container for contextual blocks: `invocation`, `access`, `composition`, `guardrails`.
 - Keeps cross-cutting structures (`metadata`, `localization`, `examples`, `prerequisites`, `feedback`).
 - Enforces resource-specific requirements (for example, `tool` must supply `how_to_use.invocation`, `document` must provide `how_to_use.access`).
+- Adds hard requirements for datasets and connectors: `content.type` must be `"dataset/spec"` or `"connector/spec"` and `content.data` carries the structured contract.
 - Supports MCP discovery across `/tools`, `/prompts`, `/docs`, `/workflows`, `/policies`, `/models`, and future endpoints.
+- The canonical schema identifier is `https://ardf.io/schema/v1`; keep manifest metadata in sync.
 
 ### Example Resource Catalog (ARDF)
 | ID | Type | Summary |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@
    - 2.x mejorado (`schema/enhanced_atdf_schema.json`): añade `metadata`, `localization`, `prerequisites`, `examples` y `feedback`.
    Consulta la guía de [Compatibilidad de versiones](./docs/en/version_compatibility.md) para elegir.
 
+## ARDF actualizado
+
+- El esquema ARDF v1.0.0 utiliza el identificador canónico [`https://ardf.io/schema/v1`](https://ardf.io/schema/v1). La copia local vive en `schema/ardf.schema.json`.
+- Los recursos `dataset` y `connector` deben establecer `content.type` en `"dataset/spec"` o `"connector/spec"` e incluir su carga estructurada dentro de `content.data`.
+- El manifest MCP (`mcp_manifest.json`) anuncia cada colección con `mediaType` = `application/vnd.ardf+json` y `profile` = `https://ardf.io/spec/v1` para compatibilidad con clientes MCP.
+
 2. **Redacta la descripción / Draft the descriptor**
 
 ```json

--- a/examples/ardf_samples/connector_crm.json
+++ b/examples/ardf_samples/connector_crm.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "1.0.0",
+  "resource_id": "connector_crm_v1",
+  "resource_type": "connector",
+  "description": "REST connector that exposes CRM contacts with read/write access.",
+  "when_to_use": "Use to look up, create, or update customer records from the CRM platform.",
+  "content": {
+    "type": "connector/spec",
+    "data": {
+      "interface": "http",
+      "base_url": "https://crm.internal.example.com/api",
+      "auth": {
+        "type": "bearer",
+        "env": "CRM_API_TOKEN"
+      },
+      "endpoints": [
+        {
+          "name": "list_contacts",
+          "method": "GET",
+          "path": "/contacts",
+          "query": {
+            "email": {
+              "type": "string",
+              "description": "Filter contacts by email address."
+            }
+          },
+          "response": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "email": { "type": "string", "format": "email" },
+                "first_name": { "type": "string" },
+                "last_name": { "type": "string" },
+                "lifecycle_stage": { "type": "string" }
+              }
+            }
+          }
+        },
+        {
+          "name": "update_contact",
+          "method": "PATCH",
+          "path": "/contacts/{id}",
+          "body": {
+            "type": "object",
+            "properties": {
+              "first_name": { "type": "string" },
+              "last_name": { "type": "string" },
+              "phone": { "type": "string" }
+            }
+          },
+          "response": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "updated_at": { "type": "string", "format": "date-time" }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "domain": "crm",
+    "version": "1.0.0",
+    "owner": "Sales Operations",
+    "tags": ["contacts", "customer", "connector"],
+    "quality": "beta"
+  },
+  "examples": [
+    {
+      "name": "Lookup contact by email",
+      "input": "Find the CRM record for maria.garcia@example.com",
+      "output": "Returns a contact payload with the matching email address."
+    }
+  ]
+}

--- a/examples/ardf_samples/dataset_products.json
+++ b/examples/ardf_samples/dataset_products.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.0.0",
+  "resource_id": "dataset_products_v1",
+  "resource_type": "dataset",
+  "description": "Structured catalog of products enriched with pricing and inventory signals.",
+  "when_to_use": "Consult when users ask for product availability, pricing comparisons, or SKU metadata.",
+  "content": {
+    "type": "dataset/spec",
+    "data": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "sku": { "type": "string", "description": "Internal stock keeping unit." },
+          "name": { "type": "string", "description": "Localized product name." },
+          "category": { "type": "string", "description": "Merchandising category path." },
+          "price": { "type": "number", "description": "Current list price in minor currency units." },
+          "currency": { "type": "string", "description": "ISO-4217 currency code." },
+          "inventory_level": { "type": "integer", "description": "Available units ready to ship." },
+          "updated_at": { "type": "string", "format": "date-time", "description": "Last synchronization timestamp." }
+        },
+        "required": ["sku", "name", "price", "currency", "inventory_level"]
+      },
+      "query": "SELECT sku, name, category, price, currency, inventory_level, updated_at FROM analytics.products WHERE sku = :sku",
+      "connector": "connector_crm_v1"
+    }
+  },
+  "metadata": {
+    "domain": "retail",
+    "version": "1.0.0",
+    "owner": "Data Platform",
+    "tags": ["catalog", "pricing", "inventory"],
+    "quality": "gold"
+  },
+  "examples": [
+    {
+      "name": "Check stock for a SKU",
+      "input": "How many units of SKU-90210 do we have available?",
+      "output": "Returns the inventory_level and pricing information for SKU-90210."
+    }
+  ]
+}

--- a/mcp_manifest.json
+++ b/mcp_manifest.json
@@ -2,16 +2,63 @@
   "name": "ARDF Resource Server",
   "version": "1.0.0",
   "description": "MCP-compatible server exposing ARDF resources for agents.",
+  "schema": {
+    "id": "https://ardf.io/schema/v1",
+    "path": "/schema/ardf.schema.json",
+    "mediaType": "application/vnd.ardf+json",
+    "profile": "https://ardf.io/spec/v1"
+  },
   "resources": [
-    { "type": "tool", "path": "/tools" },
-    { "type": "prompt", "path": "/prompts" },
-    { "type": "document", "path": "/documents" },
-    { "type": "workflow", "path": "/workflows" },
-    { "type": "policy", "path": "/policies" },
-    { "type": "model", "path": "/models" }
+    {
+      "type": "tool",
+      "path": "/tools",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "prompt",
+      "path": "/prompts",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "document",
+      "path": "/documents",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "workflow",
+      "path": "/workflows",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "policy",
+      "path": "/policies",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "model",
+      "path": "/models",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "dataset",
+      "path": "/datasets",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    },
+    {
+      "type": "connector",
+      "path": "/connectors",
+      "mediaType": "application/vnd.ardf+json",
+      "profile": "https://ardf.io/spec/v1"
+    }
   ],
   "meta": {
-    "ardf_schema": "/schema/ardf.schema.json",
     "contact": "support@example.org"
   }
 }

--- a/schema/ardf.schema.json
+++ b/schema/ardf.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://example.org/ardf.schema.json",
+  "$id": "https://ardf.io/schema/v1",
   "title": "Agent Resource Description Format (ARDF) v1.0.0",
   "type": "object",
   "required": [
@@ -222,6 +222,38 @@
           }
         }
       }
+    },
+    {
+      "if": {"properties": {"resource_type": {"const": "dataset"}}},
+      "then": {
+        "required": ["content"],
+        "properties": {
+          "content": {
+            "properties": {
+              "type": {
+                "const": "dataset/spec"
+              }
+            },
+            "required": ["type", "data"]
+          }
+        }
+      }
+    },
+    {
+      "if": {"properties": {"resource_type": {"const": "connector"}}},
+      "then": {
+        "required": ["content"],
+        "properties": {
+          "content": {
+            "properties": {
+              "type": {
+                "const": "connector/spec"
+              }
+            },
+            "required": ["type", "data"]
+          }
+        }
+      }
     }
   ],
   "$defs": {
@@ -433,6 +465,39 @@
                   "schema": {"type": "object"},
                   "query": {"type": "string"},
                   "connector": {"type": "string"}
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        {
+          "if": {"properties": {"type": {"const": "connector/spec"}}},
+          "then": {
+            "properties": {
+              "data": {
+                "type": "object",
+                "required": ["interface", "endpoints"],
+                "properties": {
+                  "interface": {"type": "string"},
+                  "base_url": {"type": "string", "format": "uri"},
+                  "auth": {"type": "object"},
+                  "endpoints": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": ["name", "method", "path"],
+                      "properties": {
+                        "name": {"type": "string"},
+                        "method": {"type": "string"},
+                        "path": {"type": "string"},
+                        "query": {"type": "object"},
+                        "body": {"type": "object"},
+                        "response": {"type": "object"}
+                      },
+                      "additionalProperties": true
+                    }
+                  }
                 },
                 "additionalProperties": true
               }

--- a/server_ardf_mcp.py
+++ b/server_ardf_mcp.py
@@ -14,6 +14,7 @@ from jsonschema import validators
 
 APP_ROOT = Path(__file__).parent
 SAMPLES_DIR = APP_ROOT / "examples" / "ardf_samples"
+UTF8_BOM_TOLERANT = "utf-8-sig"
 MANIFEST_PATH = APP_ROOT / "mcp_manifest.json"
 SCHEMA_PATH = APP_ROOT / "schema" / "ardf.schema.json"
 
@@ -60,7 +61,7 @@ class ResourceIndex:
     def _load_all(self) -> List[Dict[str, object]]:
         resources: List[Dict[str, object]] = []
         for path in sorted(self.directory.glob("*.json")):
-            with path.open("r", encoding="utf-8") as handle:
+            with path.open("r", encoding=UTF8_BOM_TOLERANT) as handle:
                 resources.append(json.load(handle))
         return resources
 
@@ -76,7 +77,7 @@ class ResourceIndex:
         validator = get_validator()
         for path in sorted(self.directory.glob("*.json")):
             try:
-                with path.open("r", encoding="utf-8") as handle:
+                with path.open("r", encoding=UTF8_BOM_TOLERANT) as handle:
                     data = json.load(handle)
             except Exception as e:
                 errors.append({


### PR DESCRIPTION
## Summary
- load ARDF sample JSON using a BOM-tolerant UTF-8 codec so legacy descriptors with byte order marks do not crash the MCP server
- add dataset and connector ARDF samples and advertise the canonical media type/profile in the manifest
- enforce dataset/connector schema contracts, publish the canonical schema metadata in the manifest, and document the new requirements

## Testing
- python examples/ardf_samples/validate_python.py examples/ardf_samples/dataset_products.json
- python examples/ardf_samples/validate_python.py examples/ardf_samples/connector_crm.json
- python - <<'PY'
import asyncio
import json
from httpx import ASGITransport, AsyncClient
from server_ardf_mcp import app

async def fetch(client, path):
    response = await client.request("GET", path)
    return response

async def main():
    transport = ASGITransport(app=app)
    async with AsyncClient(transport=transport, base_url="http://test") as client:
        manifest = await fetch(client, "/manifest")
        print("/manifest", manifest.status_code)
        print(json.dumps(manifest.json(), indent=2))
        for path in ["/datasets", "/connectors", "/resources"]:
            response = await fetch(client, path)
            print(path, response.status_code)
            print(json.dumps(response.json(), indent=2))

asyncio.run(main())
PY
- n8n --version

------
https://chatgpt.com/codex/tasks/task_e_68e5661aa64c832d86213198b2e10442