### PR TITLE
fix: allow CORS POST access for validation endpoint

### DIFF
--- a/server_ardf_mcp.py
+++ b/server_ardf_mcp.py
@@ -26,7 +26,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
     allow_credentials=False,
-    allow_methods=["GET", "OPTIONS"],
+    allow_methods=["GET", "OPTIONS", "POST"],
     allow_headers=["*"]
 )
 


### PR DESCRIPTION
## Summary
- allow POST requests in the CORS middleware so browsers can call the validation endpoint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e59eb9540c832d80b3c15da8c80f7b