### PR TITLE
ci: add ardf validation workflow and release notes

### DIFF
--- a/.github/workflows/ardf-ci.yml
+++ b/.github/workflows/ardf-ci.yml
@@ -1,0 +1,175 @@
+name: ARDF MCP CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    paths:
+      - 'server_ardf_mcp.py'
+      - 'schema/**'
+      - 'examples/ardf_samples/**'
+      - 'tests/**'
+      - '.github/workflows/ardf-ci.yml'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'docs/**'
+
+env:
+  PYTHON_VERSION: '3.11'
+  NODE_VERSION: '20'
+  N8N_CLI: ${{ vars.N8N_CLI || secrets.N8N_CLI || '0' }}
+
+jobs:
+  ardf:
+    name: Validate ARDF MCP stack
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio httpx requests uvicorn[standard]
+
+      - name: Validate ARDF samples (Python)
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import json
+          from jsonschema import Draft202012Validator
+
+          schema = json.loads(Path('schema/ardf.schema.json').read_text(encoding='utf-8'))
+          validator = Draft202012Validator(schema)
+
+          samples = sorted(Path('examples/ardf_samples').glob('*.json'))
+          failures = []
+          for sample in samples:
+              payload = json.loads(sample.read_text(encoding='utf-8'))
+              errors = list(validator.iter_errors(payload))
+              if errors:
+                  failures.append((sample, errors))
+
+          if failures:
+              for sample, errors in failures:
+                  print(f'Errors in {sample}:')
+                  for error in errors:
+                      location = '.'.join(str(p) for p in error.path) or '<root>'
+                      print(f'  - {location}: {error.message}')
+              raise SystemExit(1)
+          else:
+              print(f'Validated {len(samples)} samples with Python jsonschema')
+          PY
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Node validation dependencies
+        run: npm install --prefix examples/ardf_samples --no-save ajv@^8 ajv-formats@^3
+
+      - name: Validate ARDF samples (Node)
+        run: |
+          for sample in examples/ardf_samples/*.json; do
+            echo "Validating $sample with Node"
+            node examples/ardf_samples/validate_node.js "$sample"
+          done
+
+      - name: Start MCP server
+        run: |
+          uvicorn server_ardf_mcp:app --host 0.0.0.0 --port 8000 &
+          echo $! > uvicorn.pid
+          sleep 5
+
+      - name: Check MCP health endpoint
+        run: |
+          for attempt in {1..10}; do
+            if curl -fsS http://127.0.0.1:8000/health > /dev/null; then
+              echo "Server healthy"
+              exit 0
+            fi
+            echo "Waiting for server (attempt $attempt)"
+            sleep 1
+          done
+          echo "Server failed to start" >&2
+          exit 1
+
+      - name: Verify served schema matches canonical file
+        run: |
+          python - <<'PY'
+          import json
+          import pathlib
+          import requests
+
+          base = 'http://127.0.0.1:8000'
+          resp = requests.get(f'{base}/schema/ardf.schema.json', timeout=10)
+          resp.raise_for_status()
+          served = resp.json()
+          local = json.loads(pathlib.Path('schema/ardf.schema.json').read_text(encoding='utf-8'))
+          if served != local:
+              raise SystemExit('Served schema does not match local canonical file')
+          print('Served schema matches local canonical file')
+          PY
+
+      - name: Negative validation checks over HTTP
+        run: |
+          python - <<'PY'
+          import requests
+
+          base = 'http://127.0.0.1:8000/validate'
+
+          invalid_dataset = {
+              "schema_version": "1.0.0",
+              "resource_id": "ci_invalid_dataset",
+              "resource_type": "dataset",
+              "description": "Dataset missing the dataset/spec type",
+              "content": {"type": "document/ref", "data": {}}
+          }
+          invalid_connector = {
+              "schema_version": "1.0.0",
+              "resource_id": "ci_invalid_connector",
+              "resource_type": "connector",
+              "description": "Connector without endpoints",
+              "content": {
+                  "type": "connector/spec",
+                  "data": {"interface": "http", "base_url": "https://api.example.com"}
+              }
+          }
+
+          for payload, expected in [
+              (invalid_dataset, 'dataset/spec'),
+              (invalid_connector, 'endpoints')
+          ]:
+              response = requests.post(base, json=payload, timeout=10)
+              response.raise_for_status()
+              body = response.json()
+              assert body.get('count', 0) > 0, 'Expected validation errors'
+              messages = [error.get('message', '') for error in body.get('errors', [])]
+              if not any(expected in message for message in messages):
+                  raise SystemExit(f'Missing expected marker "{expected}" in errors: {messages}')
+          print('Negative validation checks succeeded')
+          PY
+
+      - name: Run pytest suite
+        run: pytest tests/test_ardf_mcp_server.py -v
+
+      - name: Optional n8n smoke test
+        if: env.N8N_CLI == '1'
+        run: n8n --version
+
+      - name: Stop MCP server
+        if: always()
+        run: |
+          if [ -f uvicorn.pid ]; then
+            kill "$(cat uvicorn.pid)" || true
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No hay cambios aún._
 
+## [1.0.0] - 2025-10-07
+
+### ✅ Added
+- Canonical ARDF schema identifier (`https://ardf.io/schema/v1`) and hard requirements for dataset/connector descriptors enforced via JSON Schema `if/then` rules.
+- Sample ARDF descriptors for datasets and connectors demonstrating the stricter invariants.
+- FastAPI validation endpoint coverage for both GET and POST so clients can check descriptors programmatically.
+
+### 🔄 Changed
+- MCP manifest now advertises the canonical schema metadata and explicitly lists dataset/connector resource collections.
+- ARDF MCP server mounts the schema at `/schema/ardf.schema.json` and exposes `/datasets` and `/connectors` resource collections alongside `/resources`.
+
+### 🐛 Fixed
+- Updated CORS middleware configuration to include POST requests so cross-origin browsers can call `/validate`.
+
+### 🧪 Tests
+- `pytest tests/test_ardf_mcp_server.py`
+- Negative HTTP validation checks for dataset/connector invariants via `/validate`.
+
+### 📚 Documentation
+- README and agent guidance updated with canonical schema, dataset/connector rules, manifest expectations, and validation endpoints.
+
+
+---
+
+### Legacy ATDF Releases
+
 ## [2.1.0] - 2025-02-14
 
 ### ⚠️ Breaking (With Migration Path)
@@ -234,8 +260,9 @@ When adding new entries to this changelog, please follow these guidelines:
 
 ## Version History
 
+- **v1.0.0 (2025-10-07)**: Canonical ARDF schema, stricter dataset/connector invariants, MCP alignment, validation endpoints.
 - **v2.0.1**: Global date updates from 2024 to 2025 across all documentation and examples
 - **v2.0.0**: Enriched Response Standard, enhanced schemas, multilingual improvements
 - **v1.2.0**: Multilingual support, basic validation, SDK foundation
 - **v1.1.0**: Basic specification, JSON schemas, documentation
-- **v1.0.0**: Initial release 
+- **v1.0.0 (legacy, 2023-XX-XX)**: Initial release of ATDF 

--- a/server_ardf_mcp.py
+++ b/server_ardf_mcp.py
@@ -26,7 +26,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
     allow_credentials=False,
-    allow_methods=["GET", "OPTIONS"],
+    allow_methods=["GET", "OPTIONS", "POST"],
     allow_headers=["*"]
 )
 

--- a/tests/test_ardf_mcp_server.py
+++ b/tests/test_ardf_mcp_server.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from httpx import ASGITransport, AsyncClient, Response
+from starlette.datastructures import Headers
 
 from server_ardf_mcp import app, get_validator
 
@@ -59,6 +60,26 @@ def test_validate_endpoint_accepts_valid_descriptors():
     body = response.json()
     assert body["count"] == 0
     assert body["errors"] == []
+
+
+def test_validate_endpoint_cors_preflight_allows_post():
+    cors_middleware = next((m for m in app.user_middleware if m.cls.__name__ == "CORSMiddleware"), None)
+    assert cors_middleware is not None, "Expected FastAPI app to register CORSMiddleware"
+
+    instance = cors_middleware.cls(app=app, **cors_middleware.kwargs)
+    headers = Headers(
+        {
+            "origin": "https://example.com",
+            "access-control-request-method": "POST",
+        }
+    )
+
+    response = instance.preflight_response(request_headers=headers)
+    allow_methods = response.headers.get("access-control-allow-methods")
+    assert allow_methods, "Preflight response is missing access-control-allow-methods header"
+
+    advertised_methods = {method.strip().upper() for method in allow_methods.split(",")}
+    assert "POST" in advertised_methods, f"Expected POST to be allowed, got: {allow_methods}"
 
 
 def test_dataset_descriptor_rejects_incorrect_content_type():


### PR DESCRIPTION
## Summary
- add an ARDF-focused CI workflow that validates sample descriptors with Python and Node, boots the MCP server, runs HTTP health and regression checks, and exercises the pytest suite
- document the 2025-10-07 ARDF v1.0.0 release in the changelog, highlighting schema invariants, manifest alignment, validation coverage, and documentation updates

## Testing
- pytest tests/test_ardf_mcp_server.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e59eb9540c832d80b3c15da8c80f7b